### PR TITLE
Styling issue fixes and catching an edge case for future transactions

### DIFF
--- a/client/src/components/RequireAuthentication.js
+++ b/client/src/components/RequireAuthentication.js
@@ -3,7 +3,6 @@ import { Alert, AlertTitle } from '@mui/material'
 
 const RequireAuthentication = ({ children }) => {
 	const accesstoken = useSelector((state) => state.users.accesstoken);
-  console.log(accesstoken)
   if (!accesstoken) {
     return (
       <>

--- a/client/src/components/Transactions/AddTransactionItem.js
+++ b/client/src/components/Transactions/AddTransactionItem.js
@@ -28,6 +28,7 @@ const default_state = {
 
 export default function AddTransactionItem() {
     const [open, setOpen] = React.useState(false);
+    const [openError, setOpenError] = React.useState(false);
     const [transaction, setTransaction] = React.useState(default_state);
     const dispatch = useDispatch();
 
@@ -39,8 +40,13 @@ export default function AddTransactionItem() {
     }
 
     const resetFields = () => {
+        setOpenError(false);
         setOpen(false);
         setTransaction(default_state);
+    }
+
+    const closeErrorMessage = () => {
+        setOpenError(false);
     }
 
     const handleClickOpen = () => {
@@ -48,6 +54,12 @@ export default function AddTransactionItem() {
     };
 
     const handleAdd = () => {
+        let today = new Date();
+        let transactionDate = new Date(transaction.date);
+        if (transactionDate > today) {
+            setOpenError(true);
+            return;
+        }
         if (transaction.merchantName && transaction.amount && transaction.address && transaction.date && transaction.transactionType && transaction.currency && transaction.paymentMethod) {
             dispatch(addTransactionsAsync([transaction]));
             resetFields();
@@ -59,6 +71,17 @@ export default function AddTransactionItem() {
             <Button variant="outlined" onClick={handleClickOpen}>
                 Add Transaction
             </Button>
+            <Dialog open={openError} onClose={closeErrorMessage} maxWidth="md">
+                <DialogTitle>Error</DialogTitle>
+                <DialogContent >
+                    <DialogContentText>
+                        Please ensure the transaction date is no later than today's date.
+                    </DialogContentText>
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={closeErrorMessage}>Continue</Button>
+                </DialogActions>
+            </Dialog>
             <Dialog open={open} onClose={resetFields} maxWidth="md">
                 <DialogTitle>Add Transaction</DialogTitle>
                 <DialogContent >

--- a/client/src/components/Transactions/BulkUpload.js
+++ b/client/src/components/Transactions/BulkUpload.js
@@ -1,11 +1,18 @@
-import { useEffect, useState } from "react";
+import * as React from "react";
 import Papa from "papaparse";
-import { Button } from "@mui/material";
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle
+} from '@mui/material';
 import { useDispatch } from 'react-redux';
 import { addTransactionsAsync } from '../../redux/thunks/transactionThunk';
 
 export default function BulkUpload() {
-  const [transactions, setTransactions] = useState(null);
+  const [open, setOpen] = React.useState(false);
   const dispatch = useDispatch();
 
   const handleUpload = (event) => {
@@ -15,8 +22,11 @@ export default function BulkUpload() {
         header: true,
         skipEmptyLines: true,
         complete: (results) => {
-          setTransactions(results.data);
-          dispatch(addTransactionsAsync(results.data));
+          let cleanData = filterFutureDates(results.data);
+          if (cleanData.length < results.data.length) {
+            setOpen(true);
+          }
+          dispatch(addTransactionsAsync(cleanData));
         },
         error: (error) => {
             console.log(error)
@@ -25,8 +35,35 @@ export default function BulkUpload() {
     }
   };
 
+  const closeMessage = () => {
+    setOpen(false);
+  }
+
+  function filterFutureDates(data) {
+    let cleanData = [];
+    let today = new Date();
+    for (let entry of data) {
+      if (new Date(entry.date) <= today) {
+        cleanData.push(entry);
+      }
+    }
+    return cleanData;
+  }
+
   return (
     <div style={{ marginLeft: "5px" }}>
+      <Dialog open={open} onClose={closeMessage} maxWidth="md">
+                <DialogTitle>Warning</DialogTitle>
+                <DialogContent >
+                    <DialogContentText>
+                        Some transactions were not included due to having a transaction date in the future.
+                        Only transactions with dates in the past are allowed, so not all transactions were added.
+                    </DialogContentText>
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={closeMessage}>Continue</Button>
+                </DialogActions>
+            </Dialog>
       <Button variant="outlined" component="label">
         Bulk upload
         <input type="file" hidden accept=".csv" onChange={handleUpload} />

--- a/client/src/components/Transactions/UpdateTransactionItem.js
+++ b/client/src/components/Transactions/UpdateTransactionItem.js
@@ -19,6 +19,7 @@ import { getDateString } from '../../utils/date.js';
 export default function UpdateTransactionItem(props) {
     const dispatch = useDispatch();
     const [open, setOpen] = React.useState(false);
+    const [openError, setOpenError] = React.useState(false);
     const default_state = {
         merchantName: '',
         amount: '',
@@ -39,8 +40,13 @@ export default function UpdateTransactionItem(props) {
     }
 
     const resetFields = () => {
+        setOpenError(false);
         setOpen(false);
         setTransaction(default_state);
+    }
+
+    const closeErrorMessage = () => {
+        setOpenError(false);
     }
 
     const handleClickOpen = () => {
@@ -49,6 +55,12 @@ export default function UpdateTransactionItem(props) {
     };
 
     const handleUpdate = () => {
+        let today = new Date();
+        let transactionDate = new Date(transaction.date);
+        if (transactionDate > today) {
+            setOpenError(true);
+            return;
+        }
         if (transaction.amount && transaction.date && transaction.transactionType && transaction.currency && transaction.paymentMethod) {
             dispatch(updateTransactionAsync(transaction))
             resetFields();
@@ -61,6 +73,17 @@ export default function UpdateTransactionItem(props) {
             <Button onClick={handleClickOpen}>
                 Update Transaction
             </Button>
+            <Dialog open={openError} onClose={closeErrorMessage} maxWidth="md">
+                <DialogTitle>Error</DialogTitle>
+                <DialogContent >
+                    <DialogContentText>
+                        Please ensure the transaction date is no later than today's date.
+                    </DialogContentText>
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={closeErrorMessage}>Continue</Button>
+                </DialogActions>
+            </Dialog>
             <Dialog open={open} onClose={resetFields} maxWidth="md">
                 <DialogTitle>Update Transaction</DialogTitle>
                 <DialogContent >

--- a/client/src/components/Transactions/ViewTransactionsItem.js
+++ b/client/src/components/Transactions/ViewTransactionsItem.js
@@ -23,10 +23,10 @@ const dialogTheme = {
 
     '& .MuiDialogActions-root': {
         padding: '15px',
-        'margin-top': '5px'
+        'marginTop': '5px'
     },
     '& .MuiDialog-paper': {
-        "min-width": "60%",
+        "minWidth": "60%",
     },
 
 
@@ -37,7 +37,7 @@ const dialogTheme = {
  */
 const DialogHeadings = {
     fontWeight: 'bold',
-    "margin-top": '20px'
+    "marginTop": '20px'
 }
 
 

--- a/client/src/redux/services/fetchHelper.js
+++ b/client/src/redux/services/fetchHelper.js
@@ -1,5 +1,9 @@
-const ENDPOINT = "https://financetracker-backend.onrender.com";
-// const ENDPOINT = "http://localhost:3001";
+let ENDPOINT;
+if (process.env.NODE_ENV === 'development') {
+	ENDPOINT = "http://localhost:3001";
+} else {
+	ENDPOINT = "https://financetracker-backend.onrender.com";
+}
 
 const fetchHelper = async (path, method, body) => {
 	const accesstoken = localStorage.getItem("accesstoken")


### PR DESCRIPTION
There was an issue with converting the currency for transactions that are in a foreign currency and have a date in the future. We decided to restrict users from adding a transaction that is dated in the future, so this changes Add, Update, and Bulk Add transactions. For bulk add, it will filter out transactions that are in the future, so some transactions can still be added, but not all. A dialog popup appears if the user tries to add or update a transaction to be in the future.