### PR TITLE
bug fix: add transaction creates new description column

### DIFF
--- a/client/src/components/Transactions/AddTransactionItem.js
+++ b/client/src/components/Transactions/AddTransactionItem.js
@@ -191,7 +191,7 @@ export default function AddTransactionItem() {
                         label="Description"
                         type="text"
                         fullWidth
-                        name="description (optional)"
+                        name="description"
                         onChange={handleChange}
                         variant="standard"
                         sx={{ mb: 2 }}


### PR DESCRIPTION
fixed minor bug where the transaction description is placed in a new column called "description (optional)" instead of the actual description column