### PR TITLE
fix date format

### DIFF
--- a/client/src/components/Savings/ViewSavingsItem.js
+++ b/client/src/components/Savings/ViewSavingsItem.js
@@ -51,6 +51,8 @@ const SavingsItemButton = (props) => {
     setOpen(false)
   }
 
+  const [dateStr] = props.item.date.split('T')
+
   return (
     <div>
       <Button onClick={handleClickOpen}>More Info</Button>
@@ -89,7 +91,7 @@ const SavingsItemButton = (props) => {
           <Typography gutterBottom>{props.item.address}</Typography>
 
           <Typography sx={DialogHeadings}>Date:</Typography>
-          <Typography gutterBottom>{props.item.date}</Typography>
+          <Typography gutterBottom>{dateStr}</Typography>
           <Typography sx={DialogHeadings}>Currency:</Typography>
           <Typography gutterBottom>{props.item.currency}</Typography>
 

--- a/client/src/components/Transactions/ViewTransactionsItem.js
+++ b/client/src/components/Transactions/ViewTransactionsItem.js
@@ -53,6 +53,8 @@ const TransactionsItemButton = (props) => {
     setOpen(false)
   }
 
+  const [dateStr] = props.item.date.split('T')
+
   return (
     <div>
       <Button onClick={handleClickOpen}>More Info</Button>
@@ -91,7 +93,7 @@ const TransactionsItemButton = (props) => {
           <Typography gutterBottom>{props.item.address}</Typography>
 
           <Typography sx={DialogHeadings}>Date:</Typography>
-          <Typography gutterBottom>{props.item.date}</Typography>
+          <Typography gutterBottom>{dateStr}</Typography>
 
           <Typography sx={DialogHeadings}>Transaction Type:</Typography>
           <Typography gutterBottom>{props.item.transactionType}</Typography>


### PR DESCRIPTION
Fixes date format when viewing transactions and savings: 
BEFORE: shows in `"yyyy-MM-dd'T'HH:mm:ss. SSS'Z'"` format
<img width="894" alt="Screen Shot 2023-08-08 at 11 12 59 PM" src="https://github.com/phillytan/FinanceTracker/assets/96452018/3a0c16b6-fec5-401e-8e47-5dc08fd22487">

NOW: shows in `yyyy-MM-dd`
<img width="497" alt="Screen Shot 2023-08-08 at 11 12 27 PM" src="https://github.com/phillytan/FinanceTracker/assets/96452018/f968bbcd-0a4e-40fd-8fee-81248a1426a7">

